### PR TITLE
Add MacOS Support for Apple Silicon

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -69,6 +69,16 @@
 		},
 		{
 			"hidden": true,
+			"name": "vcpkg-default-presets-macos",
+			"inherits": "default-presets",
+			"generator": "Ninja",
+			"cacheVariables": {
+				"CMAKE_TOOLCHAIN_FILE": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
+				"VCPKG_TARGET_TRIPLET": "custom-arm64-osx"
+			}
+		},
+		{
+			"hidden": true,
 			"name": "system-default-presets",
 			"inherits": "default-presets",
 			"generator": "Ninja",
@@ -97,6 +107,15 @@
 			"displayName": "Vcpkg Ninja Release Build",
 			"inherits": [
 				"vcpkg-default-presets",
+				"sourcetrail-mixin-presets",
+				"release-mixin-presets"
+			]
+		},
+		{
+			"name": "vcpkg-ninja-release-macos",
+			"displayName": "Vcpkg Ninja Release Build",
+			"inherits": [
+				"vcpkg-default-presets-macos",
 				"sourcetrail-mixin-presets",
 				"release-mixin-presets"
 			]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ There are 2 ways to build the project:
 
 It is important to clone the repository with the **submodules** and the **symlinks**:
 ```
+# note under windows either development mode or an elevated git terminal/console is required or the git clone fails
+# due to failing of symlink creation
 git clone https://github.com/petermost/Sourcetrail.git --recurse-submodules --config core.symlinks=true
 ```
 and get the updates with:
@@ -57,12 +59,22 @@ git pull --recurse-submodules
     * [Maven](https://maven.apache.org/)
 * **Linux:** Because **Qt6** is build from source, additional packages are needed. Install these packages with `script/install-qt6-dependencies.sh`.
 * **Windows:** The build must be done in a **"x64 Native Tools Command Prompt for VS 2022"**.
+* **MacOS:** to compile under MacOS several things have to be installed beforehand, even with vcpkg  
+* * XCode has to be installed
+* * the following packages have to be installed via brew `brew install libtools maven autoconf autoconf-archive automake patchelf ninja`
 
-Prepare the build:
+Prepare the build in Windows and Linux:
 ```
 $ cd Sourcetrail
 $ cmake --preset vcpkg-ninja-release
 ```
+
+Prepare the build in MacOs:
+```
+$ cd Sourcetrail
+$ cmake --preset vcpkg-ninja-release-macos
+```
+
 Note that the initial compilation of the vcpkg packages (especially LLVM) will take a **long** time! Depending on your machine, it probably will take about 2 to 3 hours!
 
 Build:
@@ -100,6 +112,9 @@ $ cmake --build .
 
 ### Windows
 It's probably also possible to build with pre-installed libraries, like the original build instructions describe, but it's untested and unsupported.
+
+### MacOS
+System build was not tested under MacOS
 
 ### Used/Supported libraries: ###
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ git pull --recurse-submodules
 * **Linux:** Because **Qt6** is build from source, additional packages are needed. Install these packages with `script/install-qt6-dependencies.sh`.
 * **Windows:** The build must be done in a **"x64 Native Tools Command Prompt for VS 2022"**.
 * **MacOS:** to compile under MacOS several things have to be installed beforehand, even with vcpkg  
-* * XCode has to be installed
-* * the following packages have to be installed via brew `brew install libtools maven autoconf autoconf-archive automake patchelf ninja`
+  * XCode has to be installed
+  * the following packages have to be installed via brew `brew install libtools maven autoconf autoconf-archive automake patchelf ninja`
 
 Prepare the build in Windows and Linux:
 ```

--- a/vcpkg-custom-triplets/custom-arm64-osx.cmake
+++ b/vcpkg-custom-triplets/custom-arm64-osx.cmake
@@ -1,0 +1,24 @@
+# Prevent CMake from tracking the compiler in the port hash
+set(VCPKG_DISABLE_COMPILER_TRACKING ON)
+
+# On Apple Silicon macOS:
+# - Do NOT set VCPKG_CMAKE_SYSTEM_NAME to "Linux" or leave it blank to let CMake autodetect Darwin
+# - or you can explicitly set it to "Darwin" to clarify it’s macOS.
+
+# Uncomment the next line if you want to explicitly name Darwin:
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+
+# Set the architecture to arm64 for Apple Silicon
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+
+# Set static linking for the libraries
+set(VCPKG_LIBRARY_LINKAGE static)
+
+# On macOS, this is typically ignored; but you can leave it as-is
+set(VCPKG_CRT_LINKAGE dynamic)
+
+# If you need to handle special cases for, e.g., Catch2 on macOS,
+# you can keep your existing logic but direct it to the right OS:
+if (CMAKE_HOST_APPLE)
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCATCH_CONFIG_NO_POSIX_SIGNALS=ON")
+endif()


### PR DESCRIPTION
Added new CMakePresets and vcpkg command triplet to enable support for Apple Silicon.  
  
Update the README with instructions for MacOS