### PR TITLE
Add Haiku to platforms

### DIFF
--- a/src/lib/utility/Platform.h
+++ b/src/lib/utility/Platform.h
@@ -21,7 +21,7 @@ class Platform final
 			// These Unix implementations are similar enough for our purpose, so we don't
 			// distinguish them further for now:
 
-			return BOOST_OS_LINUX || BOOST_OS_BSD_FREE;
+			return BOOST_OS_LINUX || BOOST_OS_BSD_FREE || BOOST_OS_HAIKU;
 		}
 
 		static constexpr bool isWindows()


### PR DESCRIPTION
I wasn't aware this was still updated until I checked repology, we still have the old version and with this step it works out to complete the build for Haiku.
Another part is a missing header to fix a undefined reference for Platform, wasn't sure if I would attatched this here or not:
```diff
diff --git a/src/lib_gui/utility/utilityPathDetection.cpp b/src/lib_gui/utility/utilityPathDetection.cpp
index eea41d2..bbf5de0 100644
--- a/src/lib_gui/utility/utilityPathDetection.cpp
+++ b/src/lib_gui/utility/utilityPathDetection.cpp
@@ -1,6 +1,7 @@
 #include "utilityPathDetection.h"
 
 #include "language_packages.h"
+#include "Platform.h"
 
 #if BUILD_CXX_LANGUAGE_PACKAGE
 #      include "CxxFrameworkPathDetector.h"
```